### PR TITLE
Update deprecated `parameters()` to `extract_parameter_set_dials()`

### DIFF
--- a/05-spending_our_data.Rmd
+++ b/05-spending_our_data.Rmd
@@ -178,7 +178,7 @@ Example:
 ```{r heights-05}
 # data source: http://www.bristol.ac.uk/cmm/learning/mmsoftware/data-rev.html#oxboys
 child_heights <- read_delim(here::here("data/Oxboys.txt"), col_names = FALSE, delim = " ") %>%
-  set_names(c("child_id", "age_norm", "height", "measurement_id", "season"))
+  purrr::set_names(c("child_id", "age_norm", "height", "measurement_id", "season"))
 head(child_heights)
 ```
 
@@ -197,14 +197,7 @@ For other task it might be more suitable to split along measurement id and all c
 
 ## What proportion should be used?
 
-```{r tweetrmd, include = F}
-library(tweetrmd)
-```
-
-```{r split-size-tweet, echo = F}
-include_tweet("https://twitter.com/asmae_toumi/status/1356024351720689669?s=20")
-```
-
+https://twitter.com/asmae_toumi/status/1356024351720689669?s=20
 
 ![](images/provocative_8020.jpg)
 

--- a/12-model_tuning_and_the_dangers_of_overfitting.Rmd
+++ b/12-model_tuning_and_the_dangers_of_overfitting.Rmd
@@ -299,7 +299,8 @@ updated_params
 With the `finalize()` function, mtry was completed based on the number of predictors in the training dataset
 
 ```{r pull_dials_object-12, echo = TRUE}
-updated_params %>% pull_dials_object("mtry")
+updated_params %>%
+  extract_parameter_dials("mtry")
 ```
 
 ## What is next?

--- a/12-model_tuning_and_the_dangers_of_overfitting.Rmd
+++ b/12-model_tuning_and_the_dangers_of_overfitting.Rmd
@@ -254,7 +254,8 @@ rf_spec_tuned <- rand_forest(mtry = tune(), trees = 2000, min_n = tune()) %>%
 `tune()` returns an expression. This tags the parameters for optimization within the tidymodels framework
 
 ```{r rf-params-12, echo = TRUE}
-parameters(rf_spec_tuned)
+rf_spec_tuned %>% 
+  extract_parameter_set_dials()
 ```
 
 The notation `nparam[+]` indicates a complete numeric parameter, `nparam[?]` indicates a missing value that needs to be addressed.
@@ -274,7 +275,8 @@ min_n()
 To update/finalize or adjust the hyperparameters we can use the `update()` function to update in-place:
 
 ```{r update-params-12, echo = TRUE}
-parameters(rf_spec_tuned) %>% 
+rf_spec_tuned %>% 
+  extract_parameter_set_dials() %>% 
   update(mtry = mtry(c(1, 4)))
 ```
 
@@ -288,7 +290,7 @@ The update function may not be useful if a recipe is attached to a workflow that
 updated_params <- workflow() %>% 
   add_model(rf_spec_tuned) %>% 
   add_recipe(ames_recipe) %>% 
-  parameters() %>% 
+  extract_parameter_set_dials() %>% 
   finalize(ames_train)
 
 updated_params

--- a/13-grid_search.Rmd
+++ b/13-grid_search.Rmd
@@ -67,15 +67,15 @@ mlp_spec <-
   set_mode("regression")
 ```
 
-The argument **trace = 0** prevents extra logging of the training process. The `parameters()` function can extract the set of arguments with unknown values and set their `dials` objects. `pull_dials_object()` gives the current range of values.
+The argument **trace = 0** prevents extra logging of the training process. The `parameters()` function can extract the set of arguments with unknown values and set their `dials` objects. `extract_parameter_dials()` gives the current range of values.
 
 ```{r 13_mlp_param_hidden_units}
 mlp_param <- parameters(mlp_spec)
-mlp_param %>% pull_dials_object("hidden_units")
+mlp_param %>% extract_parameter_dials("hidden_units")
 ```
 
 ```{r 13_mlp_param_penalty}
-mlp_param %>% pull_dials_object("penalty")
+mlp_param %>% extract_parameter_dials("penalty")
 ```
 
 > For `penalty`, the random numbers are uniform on the log (base 10) scale. The values in the grid are in their natural units.
@@ -83,7 +83,7 @@ mlp_param %>% pull_dials_object("penalty")
 ![](https://media.giphy.com/media/iRBz7kiE3HsSA/giphy.gif)
 
 ```{r 13_mlp_param_epochs}
-mlp_param %>% pull_dials_object("epochs")
+mlp_param %>% extract_parameter_dials("epochs")
 ```
 
 ### Regular Grids

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,11 +51,9 @@ Imports:
     tidyverse,
     tidytuesdayR,
     tufte,
-    tweetrmd,
     workflowsets,
     probably
 Remotes: 
     hadley/emo,
-    gadenbuie/tweetrmd,
     tidymodels/learntidymodels
 biocViews: mixOmics

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,10 +1,10 @@
 Package: tmwr
 Title: Tidy Modeling with R Book Club
 Version: 0.0.1.9000
-Authors@R: c(
-  person("R4DS Online Learning Community", role = c("aut", "cre", "cph"))
-  )
-URL: https://r4ds.github.io/bookclub-tmwr, https://github.com/r4ds/bookclub-tmwr
+Authors@R: 
+    person("R4DS Online Learning Community", role = c("aut", "cre", "cph"))
+URL: https://r4ds.github.io/bookclub-tmwr,
+    https://github.com/r4ds/bookclub-tmwr
 Depends:
     R (>= 3.1.0)
 Imports: 
@@ -19,9 +19,9 @@ Imports:
     DALEX,
     DALEXtra,
     details,
+    DiagrammeR,
     dimRed,
     discrim,
-    DiagrammeR,
     earth,
     emo,
     fastICA,
@@ -40,6 +40,7 @@ Imports:
     nycflights13,
     palmerpenguins,
     patchwork,
+    probably,
     ranger,
     remotes,
     rmarkdown,
@@ -48,12 +49,12 @@ Imports:
     skimr,
     stacks,
     tidymodels,
-    tidyverse,
     tidytuesdayR,
+    tidyverse,
     tufte,
-    workflowsets,
-    probably
+    workflowsets
 Remotes: 
     hadley/emo,
     tidymodels/learntidymodels
 biocViews: mixOmics
+Encoding: UTF-8


### PR DESCRIPTION
This is due to warnings a I got when I ran the current code:
```
Warning: `parameters.model_spec()` was deprecated in tune 0.1.6.9003.
Please use `hardhat::extract_parameter_set_dials()` instead.
```
And also:
```
Error:
! `pull_dials_object()` was deprecated in dials 0.1.0
  and is now defunct.
ℹ Please use `hardhat::extract_parameter_dials()` instead.
Backtrace:
 1. updated_params %>% pull_dials_object("mtry")
 2. dials::pull_dials_object(., "mtry")
 3. lifecycle::deprecate_stop("0.1.0", "pull_dials_object()", "hardhat::extract_parameter_dials()")
 4. lifecycle:::deprecate_stop0(msg)
```